### PR TITLE
fix: incorrect dependency on libqt6svg6-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Build-Depends:
  libglib2.0-dev,
  libxrender-dev,
  libgsettings-qt-dev,
- libqt6svg6-dev,
+ qt6-svg-dev,
  libxi-dev,
  libcups2-dev,
  libgtest-dev,


### PR DESCRIPTION
Package libqt6svg6-dev has been renamed to qt6-svg-dev in Qt 6.4.2.
As Qt 6.4.2 has been published to stable repository. We just use
Qt 6.4.2 as the required minimum version for DTK6 to be built on.
Rename libqt6svg6-dev to qt6-svg-dev.

Log: fix incorrect dependency on libqt6svg6-dev
