### PR TITLE
fix: wrong product icon size in DAboutDialog

### DIFF
--- a/src/widgets/daboutdialog.cpp
+++ b/src/widgets/daboutdialog.cpp
@@ -461,7 +461,7 @@ void DAboutDialog::setProductIcon(const QIcon &icon)
 #else
     winId(); // TODO: wait for checking
     auto window = windowHandle();
-    d->logoLabel->setPixmap(icon.pixmap(window->baseSize(), window->screen()->devicePixelRatio()));
+    d->logoLabel->setPixmap(icon.pixmap(QSize(128, 128), window->screen()->devicePixelRatio()));
 #endif
 }
 


### PR DESCRIPTION
when compiled with Qt6, product icon size is set to windowHandle().baseSize() which is not the same as compiled with Qt5 (fixed size 128x128)

Log: use 128x128 pixmap in DAboutDialog::setProductIcon