### PR TITLE
fix: add security hardening flags to build configuration

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,12 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
+# 安全编译参数
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for comprehensive
security protections
2. Included -Wall flag in C/C++ compiler flags for additional warnings
3. Set linker flags with security features: RELRO, NOW binding,
noexecstack, and export dynamic
4. These changes improve binary security by enabling modern protection
mechanisms

fix: 在构建配置中添加安全加固标志

1. 添加 DEB_BUILD_MAINT_OPTIONS 并设置 hardening=+all 以实现全面的安全
保护
2. 在 C/C++ 编译器标志中包含 -Wall 以获取额外警告
3. 设置包含安全特性的链接器标志：RELRO、NOW 绑定、noexecstack 和导出动态
4. 这些更改通过启用现代保护机制来提高二进制安全性
