### PR TITLE
fix: DComboBox 修复下拉列表鼠标移出后高亮残留问题

### DIFF
--- a/examples/collections/buttonexample.cpp
+++ b/examples/collections/buttonexample.cpp
@@ -36,6 +36,9 @@ DWIDGET_USE_NAMESPACE
 ButtonExampleWindow::ButtonExampleWindow(QWidget *parent)
     : PageWindowInterface(parent)
 {
+    addExampleWindow(new DComboBoxExample(this));
+    addExampleWindow(new DFontComboBoxExample(this));
+    addExampleWindow(new DSearchComboBoxExample(this));
     addExampleWindow(new DPushButtonExample(this));
     addExampleWindow(new DWarningButtonExample(this));
     addExampleWindow(new DSuggestButtonExample(this));
@@ -46,9 +49,6 @@ ButtonExampleWindow::ButtonExampleWindow(QWidget *parent)
     addExampleWindow(new DSwitchButtonExample(this));
     addExampleWindow(new DRadioButtonExample(this));
     addExampleWindow(new DCheckButtonExample(this));
-    addExampleWindow(new DComboBoxExample(this));
-    addExampleWindow(new DFontComboBoxExample(this));
-    addExampleWindow(new DSearchComboBoxExample(this));
 }
 
 DPushButtonExample::DPushButtonExample(QWidget *parent)

--- a/include/widgets/dcombobox.h
+++ b/include/widgets/dcombobox.h
@@ -26,6 +26,7 @@ protected:
     // QComboBox interface
 public:
     virtual void showPopup() override;
+    virtual bool eventFilter(QObject *watched, QEvent *event) override;
 };
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/dcombobox.cpp
+++ b/src/widgets/dcombobox.cpp
@@ -4,6 +4,7 @@
 
 #include "dcombobox.h"
 #include "private/dcombobox_p.h"
+#include <qlogging.h>
 
 #ifndef emit
 #define emit Q_EMIT
@@ -17,10 +18,12 @@
 #include <private/qguiapplication_p.h>
 #include <qpa/qplatformtheme.h>
 
+#include <QAbstractItemView>
 #include <QListView>
 #include <QTableView>
 #include <QItemDelegate>
 #include <QTreeView>
+#include <QMouseEvent>
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QDesktopWidget>
 #endif
@@ -149,7 +152,13 @@ void DComboBox::showPopup()
     };
     // When the value of maxVisibleItems() is less than 16, use the default value of qt and return it directly to avoid displaying excess whitespace
     QComboBoxPrivateContainer *container = this->findChild<QComboBoxPrivateContainer *>();
-    if (getRowCount() <= maxVisibleItems() || !container)
+    if (!container)
+        return QComboBox::showPopup();
+
+    // Fix hover highlight residue: clear highlight when mouse leaves item area
+    container->installEventFilter(this);
+
+    if (getRowCount() <= maxVisibleItems())
         return QComboBox::showPopup();
 
     // Calculate maximum height by maximum item size
@@ -261,6 +270,22 @@ void DComboBox::showPopup()
     int offset = mapToGlobal(rect().topLeft()).y() - currentIndexTopLeft.y();
     int newY = qMax(screen.top(), qMin(container->y() + offset, screen.bottom() - container->height()));
     container->move(container->x(), newY);
+}
+
+bool DComboBox::eventFilter(QObject *watched, QEvent *event)
+{
+    if (event->type() == QEvent::Leave) {
+        QComboBoxPrivateContainer *container = this->findChild<QComboBoxPrivateContainer *>();
+        if (watched == container) {
+            // When the mouse leaves the container: set currentIndex to invalid and clear selection highlight
+            QAbstractItemView *v = view();
+            if (v->currentIndex().isValid()) {
+                v->setCurrentIndex(QModelIndex());
+            }
+        }
+    }
+
+    return QComboBox::eventFilter(watched, event);
 }
 
 DWIDGET_END_NAMESPACE

--- a/src/widgets/private/dcombobox_p.h
+++ b/src/widgets/private/dcombobox_p.h
@@ -7,6 +7,7 @@
 
 #include "dcombobox.h"
 #include <DObjectPrivate>
+#include <QPersistentModelIndex>
 
 DWIDGET_BEGIN_NAMESPACE
 


### PR DESCRIPTION
QComboBoxPrivateContainer::eventFilter 在鼠标移动时将 currentIndex
设为鼠标下的 item，但鼠标移出时未重置，导致 selection 高亮残留。
通过监听容器 Leave 事件，在鼠标移出时将 currentIndex 设为无效值清除高亮。
